### PR TITLE
feat: display location-specific maps

### DIFF
--- a/src/components/Homepage.1.tsx
+++ b/src/components/Homepage.1.tsx
@@ -9,6 +9,7 @@ import { toast } from "react-toastify"
 import Carousel from 'react-multi-carousel';
 import 'react-multi-carousel/lib/styles.css';
 import { contact } from "@/utils/translations";
+import { useLocation } from "@/context/LocationContext";
 
 const responsive = {
   superLargeDesktop: {
@@ -32,8 +33,11 @@ const responsive = {
 
 export default function Homepage() {
   const router = useRouter()
+  const { location, locations } = useLocation()
 
   const t = router.locale as keyof Language
+
+  const mapSrc = (location ? locations[location] : locations.arsta).mapSrc
 
   const [name, setName] = useState<string>("")
   const [email, setEmail] = useState<string>("")
@@ -367,8 +371,7 @@ export default function Homepage() {
             title="map"
             className="w-full h-[500px]"
             loading="lazy"
-            src={`https://www.google.com/maps/embed/v1/place?key=${process.env.NEXT_PUBLIC_GOOGLE_API
-              }&q=cumin+stockholm&language=${t === "en" ? "en" : "sv"}`}
+            src={mapSrc}
           ></iframe>
         </div>
       </div>

--- a/src/context/LocationContext.tsx
+++ b/src/context/LocationContext.tsx
@@ -8,6 +8,8 @@ interface LocationInfo {
   /** Short label used in the UI dropdown */
   shortName: string;
   phones: string[];
+  /** Google Maps embed source URL */
+  mapSrc: string;
 }
 
 const locations: Record<LocationKey, LocationInfo> = {
@@ -15,11 +17,15 @@ const locations: Record<LocationKey, LocationInfo> = {
     name: "ÅRSTAVÄGEN 39, 120 52 Årsta",
     shortName: "Buddha Årsta",
     phones: ["08-684 271 90", "0760-35 37 99"],
+    mapSrc:
+      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2037.2104655923176!2d18.05061867705999!3d59.296042113684926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f7791cc0466d9%3A0xa844d6d5435f306a!2sBuddha%20Nepal!5e0!3m2!1sen!2sse!4v1757644635036!5m2!1sen!2sse",
   },
   haga: {
     name: "Buddha Haga",
     shortName: "Buddha Haga",
     phones: ["08-684 271 90", "0760-35 37 99"],
+    mapSrc:
+      "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4068.038657368876!2d18.04833100611805!3d59.34932516386402!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f9d724ef405ef%3A0xba83e55580836315!2sYnglingagatan%209%2C%20113%2047%20Stockholm!5e0!3m2!1sen!2sse!4v1757644789600!5m2!1sen!2sse",
   },
 };
 

--- a/src/pages/about-us.tsx
+++ b/src/pages/about-us.tsx
@@ -1,14 +1,17 @@
 import { galleryArray, icons } from "@/utils/icons";
 import { Language } from "@/utils/site";
 import { about_us, homepage } from "@/utils/translations";
+import { useLocation } from "@/context/LocationContext";
 import Head from "next/head";
 import Image from "next/image";
 import { useRouter } from "next/router";
 
 export default function AboutUs() {
   const router = useRouter();
+  const { location, locations } = useLocation();
 
   const t = router.locale as Language;
+  const mapSrc = (location ? locations[location] : locations.arsta).mapSrc;
 
   return (
     <div className="">
@@ -114,9 +117,7 @@ export default function AboutUs() {
             title="map"
             className="w-full h-[400px]"
             loading="lazy"
-            src={`https://www.google.com/maps/embed/v1/place?key=${
-              process.env.NEXT_PUBLIC_GOOGLE_API
-            }&q=cumin+stockholm&language=${t === "en" ? "en" : "sv"}`}
+            src={mapSrc}
           ></iframe>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add map URLs for Årsta and Haga to location context
- render map based on chosen location on homepage and about page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c38849bcec832fb8a34c9077569f6b