### PR TITLE
Refresh homepage dishes and disable inactive location

### DIFF
--- a/public/home-dishes/caesar-sallad.svg
+++ b/public/home-dishes/caesar-sallad.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-caesar" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#11998e" />
+      <stop offset="100%" stop-color="#38ef7d" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-caesar)" />
+  <circle cx="300" cy="420" r="200" fill="#e8fff2" opacity="0.4" />
+  <path d="M200 420 C240 360 360 360 400 420" fill="#ffffff" opacity="0.5" />
+  <path d="M220 400 C260 340 340 340 380 400" fill="none" stroke="#c8ffd4" stroke-width="16" stroke-linecap="round" opacity="0.7" />
+  <text x="60" y="660" fill="#013422" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Caesar Sallad</text>
+  <text x="60" y="710" fill="#013422" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Crisp romaine &amp; shaved parmesan</text>
+</svg>

--- a/public/home-dishes/chicken-burger.svg
+++ b/public/home-dishes/chicken-burger.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-burger" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f12711" />
+      <stop offset="100%" stop-color="#f5af19" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-burger)" />
+  <ellipse cx="300" cy="420" rx="210" ry="140" fill="#fff3cd" opacity="0.6" />
+  <rect x="160" y="360" width="280" height="80" rx="40" fill="#fcd34d" opacity="0.85" />
+  <rect x="160" y="440" width="280" height="60" rx="30" fill="#8b4513" opacity="0.7" />
+  <rect x="160" y="500" width="280" height="40" rx="20" fill="#fbbf24" opacity="0.65" />
+  <text x="60" y="660" fill="#2b0d00" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Chicken Burger</text>
+  <text x="60" y="710" fill="#2b0d00" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Crispy fillet &amp; brioche bun</text>
+</svg>

--- a/public/home-dishes/chicken-tariyaki.svg
+++ b/public/home-dishes/chicken-tariyaki.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-tariyaki" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#8360c3" />
+      <stop offset="100%" stop-color="#2ebf91" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-tariyaki)" />
+  <ellipse cx="300" cy="420" rx="210" ry="150" fill="#ffffff" opacity="0.25" />
+  <path d="M180 430 C240 360 360 360 420 430" fill="#fff7f0" opacity="0.6" />
+  <path d="M200 410 C260 340 340 340 400 410" fill="none" stroke="#fde0c8" stroke-width="18" stroke-linecap="round" opacity="0.65" />
+  <text x="60" y="660" fill="#0f1c2c" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Chicken Tariyaki</text>
+  <text x="60" y="710" fill="#0f1c2c" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Sweet glaze &amp; sesame char</text>
+</svg>

--- a/public/home-dishes/chicken-timur.svg
+++ b/public/home-dishes/chicken-timur.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-timur" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#1f1c2c" />
+      <stop offset="100%" stop-color="#928dab" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-timur)" />
+  <circle cx="180" cy="220" r="120" fill="#ffffff" opacity="0.1" />
+  <circle cx="460" cy="580" r="160" fill="#ffffff" opacity="0.12" />
+  <path d="M180 530 C240 450 360 450 420 530" fill="none" stroke="#f7d08a" stroke-width="20" stroke-linecap="round" opacity="0.65" />
+  <path d="M210 500 C270 420 330 420 390 500" fill="none" stroke="#ffb36b" stroke-width="10" stroke-linecap="round" opacity="0.7" />
+  <text x="60" y="660" fill="#fdf8f0" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Chicken Timur</text>
+  <text x="60" y="710" fill="#fdf8f0" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Citrus pepper sauce &amp; seared chicken</text>
+</svg>

--- a/public/home-dishes/chilli-chicken.svg
+++ b/public/home-dishes/chilli-chicken.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-chilli" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#ff0844" />
+      <stop offset="100%" stop-color="#ffb199" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-chilli)" />
+  <path d="M160 520 C230 430 370 430 440 520" fill="#ffffff" opacity="0.25" />
+  <path d="M180 500 C250 410 350 410 420 500" fill="none" stroke="#ffe1d6" stroke-width="20" stroke-linecap="round" opacity="0.6" />
+  <path d="M240 360 C260 320 320 320 340 360" fill="none" stroke="#ffe1d6" stroke-width="16" stroke-linecap="round" />
+  <path d="M280 340 C300 300 360 300 380 340" fill="none" stroke="#ffe1d6" stroke-width="16" stroke-linecap="round" opacity="0.6" />
+  <text x="60" y="660" fill="#2c0500" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Chilli Chicken</text>
+  <text x="60" y="710" fill="#2c0500" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Crispy wok &amp; fiery peppers</text>
+</svg>

--- a/public/home-dishes/choila.svg
+++ b/public/home-dishes/choila.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-choila" x1="0%" y1="0%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#ff512f" />
+      <stop offset="100%" stop-color="#f09819" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-choila)" />
+  <g fill="#ffffff" opacity="0.2">
+    <circle cx="150" cy="160" r="90" />
+    <circle cx="470" cy="200" r="120" />
+    <circle cx="470" cy="580" r="150" />
+  </g>
+  <path d="M140 520 C200 460 400 460 460 520 L460 560 C400 620 200 620 140 560 Z" fill="#ffddc7" opacity="0.7" />
+  <path d="M160 490 C220 430 380 430 440 490" fill="none" stroke="#ffeed9" stroke-width="18" stroke-linecap="round" opacity="0.7" />
+  <text x="60" y="660" fill="#2d0600" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Choila</text>
+  <text x="60" y="710" fill="#2d0600" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="500">Smoky grilled meat salad</text>
+</svg>

--- a/public/home-dishes/fried-rice.svg
+++ b/public/home-dishes/fried-rice.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-rice" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#f6d365" />
+      <stop offset="100%" stop-color="#fda085" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-rice)" />
+  <circle cx="300" cy="420" r="200" fill="#fff8e1" opacity="0.6" />
+  <g fill="#f9c74f" opacity="0.7">
+    <circle cx="220" cy="360" r="28" />
+    <circle cx="320" cy="330" r="22" />
+    <circle cx="380" cy="380" r="25" />
+    <circle cx="270" cy="420" r="18" />
+  </g>
+  <g fill="#f94144" opacity="0.7">
+    <circle cx="250" cy="370" r="12" />
+    <circle cx="360" cy="350" r="10" />
+    <circle cx="340" cy="430" r="14" />
+  </g>
+  <text x="60" y="660" fill="#5c2f00" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Fried Rice</text>
+  <text x="60" y="710" fill="#5c2f00" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Wok tossed rice &amp; garden veggies</text>
+</svg>

--- a/public/home-dishes/grilled-chicken-pommes.svg
+++ b/public/home-dishes/grilled-chicken-pommes.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-grilled" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#f83600" />
+      <stop offset="100%" stop-color="#f9d423" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-grilled)" />
+  <path d="M160 540 C200 440 400 440 440 540" fill="#ffffff" opacity="0.25" />
+  <rect x="200" y="320" width="200" height="160" rx="32" fill="#fffcf2" opacity="0.6" />
+  <path d="M220 350 C260 310 340 310 380 350" fill="none" stroke="#ffad60" stroke-width="20" stroke-linecap="round" opacity="0.7" />
+  <path d="M200 510 C260 450 340 450 400 510" fill="none" stroke="#fff7d6" stroke-width="14" stroke-linecap="round" opacity="0.7" />
+  <text x="60" y="660" fill="#3a2000" font-size="46" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Grilled Chicken &amp; Pommes</text>
+  <text x="60" y="710" fill="#3a2000" font-size="24" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Charred fillet, herbed fries &amp; glaze</text>
+</svg>

--- a/public/home-dishes/momos.svg
+++ b/public/home-dishes/momos.svg
@@ -1,0 +1,22 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-momos" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fbd786" />
+      <stop offset="50%" stop-color="#f7797d" />
+      <stop offset="100%" stop-color="#c84e89" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" fill="url(#grad-momos)" rx="48" />
+  <g fill="#fff5e6" opacity="0.8">
+    <ellipse cx="210" cy="360" rx="120" ry="80" />
+    <ellipse cx="330" cy="390" rx="120" ry="80" />
+    <ellipse cx="390" cy="480" rx="120" ry="80" />
+    <ellipse cx="210" cy="470" rx="120" ry="80" />
+  </g>
+  <g stroke="#d9935f" stroke-width="10" stroke-linecap="round" opacity="0.7">
+    <path d="M140 360 C210 300 310 300 380 360" />
+    <path d="M240 460 C310 400 410 400 470 460" />
+  </g>
+  <text x="60" y="660" fill="#3e1220" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Momos</text>
+  <text x="60" y="710" fill="#3e1220" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="500">Steamed dumplings &amp; chilli dip</text>
+</svg>

--- a/public/home-dishes/mustang-aaloo.svg
+++ b/public/home-dishes/mustang-aaloo.svg
@@ -1,0 +1,15 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-mustang" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#654ea3" />
+      <stop offset="100%" stop-color="#eaafc8" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-mustang)" />
+  <circle cx="200" cy="320" r="120" fill="#ffffff" opacity="0.2" />
+  <circle cx="420" cy="520" r="180" fill="#ffffff" opacity="0.18" />
+  <ellipse cx="300" cy="430" rx="190" ry="130" fill="#f6d7b0" opacity="0.7" />
+  <path d="M180 420 C240 360 360 360 420 420" fill="none" stroke="#fff3df" stroke-width="16" stroke-linecap="round" opacity="0.6" />
+  <text x="60" y="660" fill="#2f103a" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Mustang Aaloo</text>
+  <text x="60" y="710" fill="#2f103a" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Roasted potatoes &amp; Himalayan spice</text>
+</svg>

--- a/public/home-dishes/noodles-chicken-scampi.svg
+++ b/public/home-dishes/noodles-chicken-scampi.svg
@@ -1,0 +1,17 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-noodles" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#00c6ff" />
+      <stop offset="100%" stop-color="#0072ff" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-noodles)" />
+  <path d="M160 460 Q300 360 440 460" fill="none" stroke="#fefefe" stroke-width="18" stroke-linecap="round" opacity="0.4" />
+  <path d="M160 500 Q300 400 440 500" fill="none" stroke="#fefefe" stroke-width="18" stroke-linecap="round" opacity="0.6" />
+  <path d="M160 540 Q300 440 440 540" fill="none" stroke="#fefefe" stroke-width="18" stroke-linecap="round" opacity="0.4" />
+  <circle cx="220" cy="360" r="30" fill="#ffe28a" opacity="0.8" />
+  <circle cx="380" cy="380" r="26" fill="#ffe28a" opacity="0.7" />
+  <circle cx="320" cy="340" r="20" fill="#ffe28a" opacity="0.6" />
+  <text x="60" y="660" fill="#ffffff" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Noodles</text>
+  <text x="60" y="710" fill="#ffffff" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Chicken &amp; scampi wok</text>
+</svg>

--- a/public/home-dishes/samosa-chaat.svg
+++ b/public/home-dishes/samosa-chaat.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-samosa" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#ffb347" />
+      <stop offset="50%" stop-color="#ff9966" />
+      <stop offset="100%" stop-color="#ff5f6d" />
+    </linearGradient>
+    <radialGradient id="glow-samosa" cx="50%" cy="40%" r="60%">
+      <stop offset="0%" stop-color="#fff2d9" stop-opacity="0.7" />
+      <stop offset="100%" stop-color="#ff9966" stop-opacity="0" />
+    </radialGradient>
+  </defs>
+  <rect width="600" height="800" fill="url(#grad-samosa)" rx="48" />
+  <circle cx="480" cy="140" r="110" fill="#fff4e0" opacity="0.35" />
+  <circle cx="140" cy="620" r="150" fill="#ffd2a1" opacity="0.25" />
+  <rect x="70" y="180" width="460" height="460" rx="48" fill="url(#glow-samosa)" opacity="0.85" />
+  <path d="M300 310 L410 520 L190 520 Z" fill="#f8c47a" stroke="#d87d2d" stroke-width="6" opacity="0.9" />
+  <path d="M320 505 C340 470 360 470 390 485" fill="none" stroke="#c55c22" stroke-width="8" stroke-linecap="round" opacity="0.5" />
+  <path d="M210 505 C230 470 250 470 280 485" fill="none" stroke="#c55c22" stroke-width="8" stroke-linecap="round" opacity="0.45" />
+  <g fill="#ffffff" opacity="0.9">
+    <circle cx="230" cy="410" r="28" />
+    <circle cx="300" cy="430" r="32" />
+    <circle cx="370" cy="400" r="26" />
+  </g>
+  <text x="60" y="660" fill="#1f1302" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Samosa Chaat</text>
+  <text x="60" y="710" fill="#1f1302" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="500">Tamarind &amp; mango-mint sauces</text>
+</svg>

--- a/public/home-dishes/snichizel.svg
+++ b/public/home-dishes/snichizel.svg
@@ -1,0 +1,14 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-snichizel" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0%" stop-color="#ffd194" />
+      <stop offset="100%" stop-color="#d1913c" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" rx="48" fill="url(#grad-snichizel)" />
+  <ellipse cx="300" cy="420" rx="200" ry="140" fill="#fff2d2" opacity="0.5" />
+  <path d="M160 440 C210 360 390 360 440 440" fill="#f5c16c" opacity="0.75" />
+  <path d="M180 420 C230 340 370 340 420 420" fill="none" stroke="#fff8ea" stroke-width="14" stroke-linecap="round" opacity="0.6" />
+  <text x="60" y="660" fill="#3a1e00" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Snichizel</text>
+  <text x="60" y="710" fill="#3a1e00" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="400">Buttered crumb &amp; lemon zest</text>
+</svg>

--- a/public/home-dishes/thukpa.svg
+++ b/public/home-dishes/thukpa.svg
@@ -1,0 +1,27 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 800">
+  <defs>
+    <linearGradient id="grad-thukpa" x1="0%" y1="100%" x2="100%" y2="0%">
+      <stop offset="0%" stop-color="#3d7bf6" />
+      <stop offset="50%" stop-color="#5ac8fa" />
+      <stop offset="100%" stop-color="#8ef5ff" />
+    </linearGradient>
+    <linearGradient id="steam" x1="0" y1="1" x2="0" y2="0">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0" />
+      <stop offset="50%" stop-color="#ffffff" stop-opacity="0.45" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+  </defs>
+  <rect width="600" height="800" fill="url(#grad-thukpa)" rx="48" />
+  <ellipse cx="300" cy="540" rx="220" ry="180" fill="#ffe9d6" opacity="0.3" />
+  <ellipse cx="300" cy="500" rx="190" ry="130" fill="#ffffff" opacity="0.6" />
+  <ellipse cx="300" cy="470" rx="170" ry="100" fill="#ffbd80" opacity="0.9" />
+  <path d="M160 470 C200 420 400 420 440 470" fill="none" stroke="#ff8a65" stroke-width="16" stroke-linecap="round" opacity="0.6" />
+  <g stroke="#ffffff" stroke-width="8" stroke-linecap="round" opacity="0.9">
+    <path d="M240 350 C220 310 230 280 250 250" />
+    <path d="M300 340 C280 300 290 270 310 240" />
+    <path d="M360 350 C340 310 350 280 370 250" />
+  </g>
+  <rect x="150" y="590" width="300" height="14" rx="7" fill="url(#steam)" opacity="0.6" />
+  <text x="60" y="660" fill="#072c53" font-size="48" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="700">Thukpa</text>
+  <text x="60" y="710" fill="#072c53" font-size="26" font-family="'Poppins', 'Segoe UI', sans-serif" font-weight="500">Aromatic Himalayan noodle soup</text>
+</svg>

--- a/src/components/Homepage.1.tsx
+++ b/src/components/Homepage.1.tsx
@@ -218,24 +218,18 @@ export default function Homepage() {
           {homepage.dishes.map((item) => (
             <div
               key={item.name.en}
-              className="food-banner rounded-md flex-none overflow-hidden w-[250px] h-[300px] md:w-[300px] md:h-[400px] flex flex-col bg-cover bg-center justify-between"
+              className="food-banner relative rounded-2xl flex-none overflow-hidden w-[250px] h-[300px] md:w-[300px] md:h-[400px] flex flex-col justify-end bg-cover bg-center shadow-xl shadow-black/10 ring-1 ring-white/10"
               style={{ backgroundImage: `url(${item.source})` }}
             >
-              {/* {item.price !== null ? (
-                      <h1 className="bg-primary w-fit p-3 md:p-5 rounded-md font-bold">
-                        {item.price}kr
-                      </h1>
-                    ) : (
-                      <div />
-                    )} */}
-              {/* <div className="bg-primary py-3 px-2 flex flex-col">
-                      <h1 className="text-[20px] md:text-[25px] font-bold">
-                        {item.name[t]}
-                      </h1>
-                      <p className="text-[12px] md:text-[18px] food-description">
-                        {item.description[t]}
-                      </p>
-                    </div> */}
+              <div className="absolute inset-0 bg-gradient-to-t from-black/80 via-black/20 to-transparent" />
+              <div className="relative w-full p-5 text-left text-white flex flex-col gap-2">
+                <h2 className="text-lg font-semibold md:text-xl lg:text-2xl">
+                  {item.name[t]}
+                </h2>
+                <p className="text-sm md:text-base leading-relaxed opacity-90">
+                  {item.description[t]}
+                </p>
+              </div>
             </div>
           ))}
         </div>

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -3,7 +3,7 @@ import Footer from "@/components/footer";
 import { icons } from "@/utils/icons";
 import Image from "next/image";
 import { useRouter } from "next/router";
-import { ReactNode, useEffect, useState } from "react";
+import { ReactNode, useEffect, useRef, useState } from "react";
 import { ToastContainer } from "react-toastify";
 import "react-toastify/dist/ReactToastify.css";
 import * as gtag from "@/utils/gtag";
@@ -13,17 +13,21 @@ import Script from "next/script";
 type PropsWithChildren = { children?: ReactNode };
 
 export default function Layout({ children }: PropsWithChildren) {
-    const [scrollTopButton, setScrollTopButton] = useState(false);
-  const [scroll, setScroll] = useState(0);
-
-  function getScrollValue() {
-    setScrollTopButton(scroll > window.scrollY && scroll > 100);
-    setScroll(window.scrollY);
-  }
+  const [scrollTopButton, setScrollTopButton] = useState(false);
+  const lastScrollY = useRef(0);
 
   useEffect(() => {
-    window.addEventListener("scroll", getScrollValue);
-  }, [scroll]);
+    const handleScroll = () => {
+      const currentScroll = window.scrollY;
+      setScrollTopButton(
+        lastScrollY.current > currentScroll && lastScrollY.current > 100
+      );
+      lastScrollY.current = currentScroll;
+    };
+
+    window.addEventListener("scroll", handleScroll);
+    return () => window.removeEventListener("scroll", handleScroll);
+  }, []);
 
   const router = useRouter();
   useEffect(() => {
@@ -36,9 +40,9 @@ export default function Layout({ children }: PropsWithChildren) {
     };
   }, [router.events]);
 
-    return (
-        <>
-        <Head>
+  return (
+    <>
+      <Head>
         <script
           dangerouslySetInnerHTML={{
             __html: `
@@ -84,6 +88,6 @@ export default function Layout({ children }: PropsWithChildren) {
       </div>
       {children}
       <Footer />
-        </>
-    )
+    </>
+  );
 }

--- a/src/components/LocationSelect.tsx
+++ b/src/components/LocationSelect.tsx
@@ -21,8 +21,15 @@ export default function LocationSelect({ className = "", onChange }: { className
         Select Location
       </option>
       {Object.entries(locations).map(([key, info]) => (
-        <option key={key} value={key}>
+        <option
+          key={key}
+          value={key}
+          disabled={!info.isActive}
+        >
           {info.shortName}
+          {!info.isActive && info.statusMessage
+            ? ` — ${info.statusMessage}`
+            : ""}
         </option>
       ))}
     </select>

--- a/src/context/LocationContext.tsx
+++ b/src/context/LocationContext.tsx
@@ -16,6 +16,10 @@ interface LocationInfo {
   phones: string[];
   /** Google Maps embed source URL */
   mapSrc: string;
+  /** Flag that states whether the location is active */
+  isActive: boolean;
+  /** Optional status or availability message */
+  statusMessage?: string;
 }
 
 const locations: Record<LocationKey, LocationInfo> = {
@@ -25,6 +29,7 @@ const locations: Record<LocationKey, LocationInfo> = {
     phones: ["08-684 271 90", "0760-35 37 99"],
     mapSrc:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d2037.2104655923176!2d18.05061867705999!3d59.296042113684926!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f7791cc0466d9%3A0xa844d6d5435f306a!2sBUDDHA%20Nepal!5e0!3m2!1sen!2sse!4v1757644635036!5m2!1sen!2sse",
+    isActive: true,
   },
   haga: {
     name: "BUDDHA Haga",
@@ -32,8 +37,12 @@ const locations: Record<LocationKey, LocationInfo> = {
     phones: ["08-684 271 90", "0760-35 37 99"],
     mapSrc:
       "https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d4068.038657368876!2d18.04833100611805!3d59.34932516386402!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x465f9d724ef405ef%3A0xba83e55580836315!2sYnglingagatan%209%2C%20113%2047%20Stockholm!5e0!3m2!1sen!2sse!4v1757644789600!5m2!1sen!2sse",
+    isActive: false,
+    statusMessage: "Coming soon",
   },
 };
+
+const defaultLocation: LocationKey = "arsta";
 
 interface LocationContextProps {
   location: LocationKey | null;
@@ -48,18 +57,28 @@ const LocationContext = createContext<LocationContextProps>({
 });
 
 export const LocationProvider = ({ children }: { children: ReactNode }) => {
-  const [location, setLocationState] = useState<LocationKey | null>(null);
+  const [location, setLocationState] = useState<LocationKey | null>(
+    locations[defaultLocation]?.isActive ? defaultLocation : null
+  );
 
   useEffect(() => {
     if (typeof window !== "undefined") {
       const stored = localStorage.getItem("location") as LocationKey | null;
-      if (stored === "arsta" || stored === "haga") {
+      if (stored && locations[stored]?.isActive) {
         setLocationState(stored);
+        return;
+      }
+      if (locations[defaultLocation]?.isActive) {
+        setLocationState(defaultLocation);
+        localStorage.setItem("location", defaultLocation);
       }
     }
   }, []);
 
   const setLocation = (loc: LocationKey) => {
+    if (!locations[loc]?.isActive) {
+      return;
+    }
     setLocationState(loc);
     if (typeof window !== "undefined") {
       localStorage.setItem("location", loc);

--- a/src/utils/translations.ts
+++ b/src/utils/translations.ts
@@ -35,76 +35,172 @@ export const homepage = {
 
   dishes: [
     {
-      price: 110,
+      price: null,
       name: {
-        en: "Chicen Tikka Masala",
-        se: "Kyckling Tikka Masala",
+        en: "Samosa Chaat",
+        se: "Samosa chaat",
       },
       description: {
-        en: "These dishes are roasted in a clay oven in a masala sauce with yoghurt, cheese, butter and nuts",
-        se: "Dessa rätter är rostade i en lerugn i en masalasås med yoghurt, ost, smör och nötter",
+        en: "Crisp samosa with tamarind chutney and mango-mint sauce.",
+        se: "Krispig samosa med tamarindsås och mango-myntasås.",
       },
-      source: "/samosa.jpeg",
-    },
-    {
-      price: 125,
-      name: {
-        en: "Mixed Chicken Grill",
-        se: "Blandad kycklinggrill",
-      },
-      description: {
-        en: "Chicken fillet marinated in tandoori, garlic and green chili, grilled in a clay oven and stir-fried fresh vegetables and sauce.",
-        se: "Kycklingfilé marinerad i tandoori, vitlök och grön chili, grillad i lerugn och wokade färska grönsaker och sås",
-      },
-      source: "/mixed-grill.jpg",
-    },
-    {
-      price: 115,
-      name: {
-        en: "Dal Pumpkin Paneer",
-        se: "Dal Pumpkin Paneer",
-      },
-      description: {
-        en: "Leaf spinach, homemade cheese with blandale lentils and in a huggable sauce.",
-        se: "Bladspenat, hemgjord ost med blandale linser och i en krambar sås",
-      },
-      source: "/chicken-tikka.jpg",
+      source: "/home-dishes/samosa-chaat.svg",
     },
     {
       price: null,
       name: {
-        en: "Korai",
-        se: "Korai",
+        en: "Thukpa",
+        se: "Thukpa",
       },
       description: {
-        en: "These dishes are roasted in a clay oven in a masala sauce with yoghurt, cheese, butter and nuts",
-        se: "Dessa rätter rostas i en lerugn i en masalasås med yoghurt, ost, smör och nötter",
+        en: "Soul-warming Himalayan noodle soup with fragrant broth.",
+        se: "Självvärmande Himalaya-nudelsoppa med doftande buljong.",
       },
-      source: "/chicken-korai.jpg",
+      source: "/home-dishes/thukpa.svg",
     },
     {
-      price: 120,
+      price: null,
       name: {
-        en: "OUMPH! KORAI",
-        se: "OUMPH! KORAI",
+        en: "Momos",
+        se: "Momos",
       },
       description: {
-        en: "Clay oven grilled soy fillets",
-        se: "Lerugnsgrillade sojafiléer",
+        en: "Steamed dumplings with chilli and sesame dressing.",
+        se: "Ångade dumplings med chili- och sesamdressing.",
       },
-      source: "/oumph-korai.jpg",
+      source: "/home-dishes/momos.svg",
     },
     {
-      price: 135,
+      price: null,
       name: {
-        en: "Lamb Biryani",
-        se: "Lamm Biryani",
+        en: "Choila",
+        se: "Choila",
       },
       description: {
-        en: "Indian party risotto made from lamb with a lot of good spices and saffron",
-        se: "Indisk festrisotto gjord på lamm med mycket goda kryddor och saffran",
+        en: "Char-grilled Nepali meat salad with toasted spices.",
+        se: "Kolgrillad nepalesisk sallad med rostade kryddor.",
       },
-      source: "/palak_paneer.jpg",
+      source: "/home-dishes/choila.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Chicken Timur",
+        se: "Chicken Timur",
+      },
+      description: {
+        en: "Pan-seared chicken glazed with citrus timur pepper.",
+        se: "Stekt kyckling glaserad med citrus och timurpeppar.",
+      },
+      source: "/home-dishes/chicken-timur.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Chilli Chicken",
+        se: "Chili-kyckling",
+      },
+      description: {
+        en: "Crispy wok-tossed chicken with bell peppers and chilli heat.",
+        se: "Krispig wokad kyckling med paprika och chilisting.",
+      },
+      source: "/home-dishes/chilli-chicken.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Noodles (Chicken & Scampi)",
+        se: "Nudlar (kyckling & skaldjur)",
+      },
+      description: {
+        en: "Silky noodles tossed with chicken, scampi and wok vegetables.",
+        se: "Silkeslena nudlar med kyckling, scampi och wokade grönsaker.",
+      },
+      source: "/home-dishes/noodles-chicken-scampi.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Fried Rice",
+        se: "Stekt ris",
+      },
+      description: {
+        en: "Fragrant fried rice cooked with seasonal vegetables.",
+        se: "Doftande stekt ris med säsongens grönsaker.",
+      },
+      source: "/home-dishes/fried-rice.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Grilled Chicken & Pommes",
+        se: "Grillad kyckling med pommes",
+      },
+      description: {
+        en: "Charred chicken fillet, herb butter glaze and golden fries.",
+        se: "Kolgrillad kycklingfilé, örtsmörsglaze och gyllene pommes.",
+      },
+      source: "/home-dishes/grilled-chicken-pommes.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Chicken Burger",
+        se: "Kycklingburgare",
+      },
+      description: {
+        en: "Crispy chicken burger layered with brioche and pickles.",
+        se: "Krispig kycklingburgare med brioche och picklad topping.",
+      },
+      source: "/home-dishes/chicken-burger.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Snichizel",
+        se: "Snichizel",
+      },
+      description: {
+        en: "Golden crumbed schnitzel brightened with lemon zest.",
+        se: "Gyllene panerad schnitzel med frisk citronskal.",
+      },
+      source: "/home-dishes/snichizel.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Caesar Sallad",
+        se: "Caesar sallad",
+      },
+      description: {
+        en: "Crisp romaine, parmesan ribbons and creamy dressing.",
+        se: "Krispig romansallad, parmesanflingor och krämig dressing.",
+      },
+      source: "/home-dishes/caesar-sallad.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Mustang Aaloo",
+        se: "Mustang aaloo",
+      },
+      description: {
+        en: "Roasted Nepali potatoes finished with smoked chilli oil.",
+        se: "Rostade nepalesiska potatisar med rökt chiliolja.",
+      },
+      source: "/home-dishes/mustang-aaloo.svg",
+    },
+    {
+      price: null,
+      name: {
+        en: "Chicken Tariyaki",
+        se: "Kyckling tariyaki",
+      },
+      description: {
+        en: "Caramelised teriyaki chicken finished with sesame seeds.",
+        se: "Karamelliserad teriyakikyckling med sesamfrön.",
+      },
+      source: "/home-dishes/chicken-tariyaki.svg",
     },
   ],
 


### PR DESCRIPTION
## Summary
- mark the Haga location as inactive so the selector shows it as coming soon and defaults visitors to Årsta
- refresh the homepage dishes list with a modern overlay and updated copy tied to new assets
- add a set of curated SVG dish illustrations to support the updated carousel imagery

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d0f7fbc154832fadf7c1cc97ee2698