### PR TITLE
Show mobile navbar location selector and phone link

### DIFF
--- a/src/components/navbar.tsx
+++ b/src/components/navbar.tsx
@@ -87,6 +87,16 @@ export default function Navbar({ id }: { id: string }) {
             />
           </div>
         </div>
+        <div className="flex items-center gap-3 text-primary md:hidden">
+          <LocationSelect
+            className="cursor-pointer bg-transparent border border-primary/50 rounded px-2 py-1 text-sm text-primary"
+          />
+          {phone && (
+            <a href={`tel:${phone.replace(/\s+/g, "")}`}>
+              <Image src={icons.phone} alt="phone" className="w-5 h-5" />
+            </a>
+          )}
+        </div>
         <Image
           src={menuOpen ? icons.close : icons.menu}
           onClick={() => setMenuOpen((prev) => !prev)}


### PR DESCRIPTION
## Summary
- expose the location dropdown in the mobile navbar alongside the call shortcut
- reuse the existing location-aware phone link on small screens

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68d82a76ec64832fba44d398a331622d